### PR TITLE
chore: add ldflags -w/-s to builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Build on ${{runner.os}}
         run: |
           #Building for main platform
-          go build -o dkc-${{env.release_version}}-${{env.goos}}-${{env.goarch}} -ldflags="-X github.com/p2p-org/dkc/cmd.ReleaseVersion=${{env.release_version}}" .
+          go build -o dkc-${{env.release_version}}-${{env.goos}}-${{env.goarch}} -ldflags="-s -w -X github.com/p2p-org/dkc/cmd.ReleaseVersion=${{env.release_version}}" .
           tar zcf dkc-${{env.release_version}}-${{env.goos}}-${{env.goarch}}.tar.gz dkc-${{env.release_version}}-${{env.goos}}-${{env.goarch}}
           shasum -a 256 dkc-${{env.release_version}}-${{env.goos}}-${{env.goarch}}.tar.gz >dkc-${{env.release_version}}-${{env.goos}}-${{env.goarch}}.sha256
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 	e2types "github.com/wealdtech/go-eth2-types/v2"
 )
 
-var ReleaseVersion = "v0.0.1"
+var ReleaseVersion string
 
 var (
 	cfgFile string
@@ -47,12 +47,12 @@ func init() {
 }
 func initConfig() {
 	viper.SetConfigFile(cfgFile)
+	viper.Set("version", ReleaseVersion)
 
 	viper.SetEnvPrefix("DKC")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 	if err := viper.ReadInConfig(); err == nil {
-		viper.Set("version", ReleaseVersion)
 		utils.InitLogging()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -4,8 +4,6 @@ import (
 	"github.com/p2p-org/dkc/cmd"
 )
 
-var ReleaseVersion = "v0.0.1"
-
 func main() {
 	cmd.Execute()
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,14 +6,21 @@
     ...
   }: let
     inherit (inputs'.ethereum-nix.packages) mcl bls;
+    pname = "dkc";
+    version = "1.0.0";
     dkc = pkgs.buildGoModule {
-      pname = "dkc";
-      version = "1.0.0";
+      inherit pname version;
       src = ../.;
 
       vendorHash = "sha256-EtGm+9jpGGB+/aUzIyFfe3ZbyhqliL3G9qJBf2nKseY=";
 
       buildInputs = [mcl bls];
+
+      ldflags = [
+        "-s"
+        "-w"
+        "-X github.com/p2p-org/dkc/cmd.ReleaseVersion=${version}"
+      ];
     };
   in {
     packages.dkc = dkc;


### PR DESCRIPTION
Changes:
* add `-s` and `-w` ldflags to build
* set version at the start, not only if read config was successful 