### PR TITLE
Wallet name

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -49,6 +49,7 @@ distributed-wallets:                #Distributed-wallets section
   path: ./wallet                    #Path to distributed wallet (Default: None)
   passphrases: ./passphrases.txt    #Path to file containing passphrases for unlocking/locking accounts (Default: None)
   threshold: 2                      #Threshlod value (Default: None)
+  walletname: myDKWallet
   peers:                            #Peers dict, number of peers must be greater than threshold value (Default: None)
     10: old1:9091
     20: old2:9091

--- a/cmd/split/helpers.go
+++ b/cmd/split/helpers.go
@@ -22,6 +22,7 @@ type SplitRuntime struct {
 	threshold      uint32
 	walletsMap     map[uint64]utils.DWallet
 	peersIDs       []uint64
+	walletName     string
 }
 
 type AccountExtends struct {
@@ -64,6 +65,7 @@ func newSplitRuntime() (*SplitRuntime, error) {
 	sr.dWalletsPath = dWalletConfig.Path
 	sr.ndWalletsPath = ndWalletConfig.Path
 	sr.threshold = dWalletConfig.Threshold
+	sr.walletName = dWalletConfig.WalletName
 	utils.LogSplit.Debug().Msgf("getting input passwords from %s", ndWalletConfig.Passphrases)
 	sr.passphrasesIn, err = utils.GetAccountsPasswords(ndWalletConfig.Passphrases)
 	if err != nil {
@@ -96,6 +98,9 @@ func (sr *SplitRuntime) validate() error {
 
 func (sr *SplitRuntime) createWallets() error {
 	walletName := uuid.New().String()
+	if sr.walletName != "" {
+		walletName = sr.walletName
+	}
 	for id, peer := range sr.peers {
 		res, err := regexp.Compile(`:.*`)
 		if err != nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -17,6 +17,7 @@ type DWalletConfig struct {
 	Passphrases string
 	Peers       Peers
 	Threshold   uint32
+	WalletName  string
 }
 
 func GetAccountsPasswords(path string) ([][]byte, error) {


### PR DESCRIPTION
Add an option to use a readable wallet name for the distributed split product, instead of a random UUID
