### PR TITLE
fix: thread-safety of wallet save operations

### DIFF
--- a/cmd/convert/process.go
+++ b/cmd/convert/process.go
@@ -1,6 +1,8 @@
 package convert
 
 import (
+	"runtime"
+
 	"github.com/p2p-org/dkc/utils"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -39,8 +41,11 @@ func process(data *dataIn) error {
 	// Converting Accounts - Full pipeline per account in parallel
 	utils.Log.Info().Msgf("converting accounts with parallel GetPrivateKey -> SavePrivateKey pipeline")
 
-	// Use errgroup to handle errors from parallel account processing
+	// Use errgroup to handle errors from parallel account processing.
+	// Limit concurrency: each import runs a scrypt KDF (hundreds of MiB of
+	// memory per operation), so a goroutine per account can OOM on large runs.
 	accountGroup := errgroup.Group{}
+	accountGroup.SetLimit(runtime.NumCPU())
 
 	// Process each account in parallel: GetPrivateKey -> SavePrivateKey
 	for _, acc := range accountsList {

--- a/store/cache.go
+++ b/store/cache.go
@@ -68,10 +68,9 @@ func (wc *WalletCache) PopulateFromLocationWithPrefix(ctx context.Context, locat
 		utils.Log.Info().Msgf("💾 initializing filesystem store for location: %s", location)
 	}
 
+	// Pass the store explicitly instead of e2wallet.UseStore: the package-level
+	// store is a plain global and is not safe to set from concurrent goroutines.
 	store := filesystem.New(filesystem.WithLocation(location))
-	if err := e2wallet.UseStore(store); err != nil {
-		return err
-	}
 
 	walletCount := 0
 	accountCount := 0
@@ -85,7 +84,7 @@ func (wc *WalletCache) PopulateFromLocationWithPrefix(ctx context.Context, locat
 		utils.Log.Info().Msgf("🔍 discovering wallets in location: %s", location)
 	}
 
-	for wallet := range e2wallet.Wallets() {
+	for wallet := range e2wallet.Wallets(e2wallet.WithStore(store)) {
 		walletName := wallet.Name()
 		if logPrefix != "" {
 			utils.Log.Info().Msgf("📁 processing wallet: %s [%s]", walletName, logPrefix)
@@ -197,6 +196,16 @@ func (wc *WalletCache) PopulateFromLocationWithPrefix(ctx context.Context, locat
 	}
 
 	return nil
+}
+
+// AddWallet stores a wallet object in the cache so that all goroutines share
+// a single instance per wallet: imports on one instance are serialized by the
+// wallet's own mutex and its in-memory account index stays consistent.
+func (wc *WalletCache) AddWallet(wallet types.Wallet) {
+	wc.mu.Lock()
+	defer wc.mu.Unlock()
+
+	wc.wallets[wallet.Name()] = wallet
 }
 
 // FetchWallet retrieves a wallet from cache

--- a/store/distributed.go
+++ b/store/distributed.go
@@ -62,6 +62,9 @@ func (s *DistributedAtomicStore) CreateWallet(name string) error {
 		utils.Log.Info().Msgf("🔓 Distributed Atomic Store [Peer %d]: Wallet %s created and unlocked permanently", s.PeerID, name)
 	}
 
+	// Cache the wallet so all saves share this single unlocked instance
+	s.cache.AddWallet(wallet)
+
 	return nil
 }
 
@@ -88,7 +91,7 @@ func (s *DistributedAtomicStore) GetPrivateKey(walletName string, accountName st
 	}
 
 	// Fallback to direct wallet access if cache miss
-	wallet, err := getWallet(s.Path, walletName)
+	wallet, err := getCachedWallet(s.cache, s.Path, walletName)
 	if err != nil {
 		utils.Log.Error().Err(err).Msgf("❌ Distributed Atomic Store [Peer %d]: Failed to get wallet: %s/%s", s.PeerID, walletName, accountName)
 		return nil, err
@@ -132,7 +135,7 @@ func (s *DistributedAtomicStore) SavePrivateKey(walletName string, accountName s
 	fileMu.Lock()
 	defer fileMu.Unlock()
 
-	wallet, err := getWallet(s.Path, walletName)
+	wallet, err := getCachedWallet(s.cache, s.Path, walletName)
 	if err != nil {
 		utils.Log.Error().Err(err).Msgf("❌ Distributed Atomic Store [Peer %d]: Failed to get wallet for save: %s", s.PeerID, walletName)
 		return err

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -100,10 +100,10 @@ func getWalletsAccountsMap(ctx context.Context, location string) ([]AccountsData
 	accs := []AccountsData{}
 	wallets := []string{}
 	store := filesystem.New(filesystem.WithLocation(location))
-	if err := e2wallet.UseStore(store); err != nil {
-		return accs, wallets, err
-	}
-	for w := range e2wallet.Wallets() {
+	// Pass the store explicitly instead of e2wallet.UseStore: the package-level
+	// store is a plain global and racing writes from concurrent goroutines can
+	// wire a wallet to the wrong store.
+	for w := range e2wallet.Wallets(e2wallet.WithStore(store)) {
 		wallets = append(wallets, w.Name())
 		for a := range w.Accounts(ctx) {
 			accs = append(accs, AccountsData{Name: a.Name(), WName: w.Name()})
@@ -136,12 +136,31 @@ func getAccountPrivateKey(ctx context.Context, account types.Account, passphrase
 	return key.Marshal(), nil
 }
 
-func getWallet(location string, n string) (types.Wallet, error) {
-	store := filesystem.New(filesystem.WithLocation(location))
-	if err := e2wallet.UseStore(store); err != nil {
+// getCachedWallet returns the shared wallet instance from the cache, opening
+// it from disk and caching it on first use. Sharing one instance per wallet
+// avoids re-reading the wallet index on every save and lets the wallet's own
+// mutex serialize concurrent imports.
+func getCachedWallet(cache *WalletCache, location string, name string) (types.Wallet, error) {
+	wallet, err := cache.FetchWallet(name)
+	if err == nil {
+		return wallet, nil
+	}
+
+	wallet, err = getWallet(location, name)
+	if err != nil {
 		return nil, err
 	}
-	w, err := e2wallet.OpenWallet(n)
+	cache.AddWallet(wallet)
+
+	return wallet, nil
+}
+
+func getWallet(location string, n string) (types.Wallet, error) {
+	store := filesystem.New(filesystem.WithLocation(location))
+	// Pass the store explicitly instead of e2wallet.UseStore: the package-level
+	// store is a plain global and racing writes from concurrent goroutines can
+	// open a wallet from the wrong store (e.g. another distributed peer's path).
+	w, err := e2wallet.OpenWallet(n, e2wallet.WithStore(store))
 	if err != nil {
 		return nil, err
 	}

--- a/store/keystore.go
+++ b/store/keystore.go
@@ -59,6 +59,9 @@ func (s *KeystoreStore) CreateWallet(name string) error {
 		utils.Log.Info().Msgf("🔓 Keystore Store: Wallet %s created and unlocked permanently", name)
 	}
 
+	// Cache the wallet so all saves share this single unlocked instance
+	s.cache.AddWallet(wallet)
+
 	return nil
 }
 
@@ -98,7 +101,7 @@ func (s *KeystoreStore) SavePrivateKey(walletName string, accountName string, da
 
 	utils.Log.Debug().Msgf("💾 Keystore Store: Importing account (wallet already unlocked): %s/%s", walletName, accountName)
 
-	wallet, err := getWallet(s.Path, walletName)
+	wallet, err := getCachedWallet(s.cache, s.Path, walletName)
 	if err != nil {
 		return err
 	}

--- a/store/nd.go
+++ b/store/nd.go
@@ -59,6 +59,9 @@ func (s *NDStore) CreateWallet(name string) error {
 		utils.Log.Info().Msgf("🔓 ND Store: Wallet %s created and unlocked permanently", name)
 	}
 
+	// Cache the wallet so all saves share this single unlocked instance
+	s.cache.AddWallet(wallet)
+
 	return nil
 }
 
@@ -98,7 +101,7 @@ func (s *NDStore) SavePrivateKey(walletName string, accountName string, data int
 
 	utils.Log.Debug().Msgf("💾 ND Store: Importing account (wallet already unlocked): %s/%s", walletName, accountName)
 
-	wallet, err := getWallet(s.Path, walletName)
+	wallet, err := getCachedWallet(s.cache, s.Path, walletName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

With many wallets, parallel `SavePrivateKey` goroutines intermittently threw exceptions from eth2-wallet. Root cause: `getWallet()` did `e2wallet.UseStore()` + `e2wallet.OpenWallet()` non-atomically, and the package-level `store` in `wealdtech/go-eth2-wallet` is a plain unsynchronized global. With multi-path stores (distributed peers, or input fallback running concurrently with output saves) a goroutine could open a wallet **from another peer's store** — producing errors like `account with name … already exists` / `wallet index corrupt`, and in the worst case silently writing a shard into the wrong peer directory.

## Fix

- Pass the filesystem store explicitly via `e2wallet.WithStore(...)` to `OpenWallet`/`Wallets`; drop all `UseStore` calls (`store/helpers.go`, `store/cache.go`).
- Share a single wallet instance per wallet through the store cache (`getCachedWallet` + `WalletCache.AddWallet`): the wallet's own mutex serializes concurrent imports and the account index is no longer re-read from disk on every save.
- `errgroup.SetLimit(runtime.NumCPU())` in `cmd/convert/process.go`: each import runs a scrypt KDF (~hundreds of MiB per op), a goroutine per account can OOM on large runs.

## Verification

Round-trip harness (12 wallets × 3 accounts, nd → distributed(3 peers) → nd) under `go run -race`:

- **before (7d4994f)**: multiple `WARNING: DATA RACE` on the e2wallet global, at `UseStore()` ← `getWallet()`
- **after**: race detector clean; all 3 peer dirs hold all 36 accounts; pubkeys after round-trip identical to source

Also: `go build ./...`, `go vet ./...` clean.

## Known remaining issues (out of scope, worth follow-up)

- `filesystem` store writes the wallet `index` file with a non-atomic `os.WriteFile` (no tmp+rename) — unsafe if two *processes* touch the same wallet dir.
- `retrieveAccountsIndex` in nd/distributed wallets silently rebuilds and rewrites the index when the read fails, so even `OpenWallet` can be a writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)